### PR TITLE
Add a keymap space-f to format buffer using conform (#817)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -600,6 +600,16 @@ require('lazy').setup({
 
   { -- Autoformat
     'stevearc/conform.nvim',
+    keys = {
+      {
+        '<leader>f',
+        function()
+          require('conform').format { async = true, lsp_fallback = true }
+        end,
+        mode = '',
+        desc = '[F]ormat buffer',
+      },
+    },
     opts = {
       notify_on_error = false,
       format_on_save = function(bufnr)


### PR DESCRIPTION
This works also for visual range selection
Copied from conform recipe:
https://github.com/stevearc/conform.nvim/blob/master/doc/recipes.md